### PR TITLE
Allow tuning of SSL verification

### DIFF
--- a/rabbitmq_admin/api.py
+++ b/rabbitmq_admin/api.py
@@ -17,11 +17,7 @@ class AdminAPI(Resource):
         """
         Name identifying this RabbitMQ cluster.
         """
-        return self._get(
-            url=self.url + '/api/cluster-name',
-            headers=self.headers,
-            auth=self.auth
-        )
+        return self._get(url=self.url + '/api/cluster-name')
 
     def list_nodes(self):
         """

--- a/rabbitmq_admin/base.py
+++ b/rabbitmq_admin/base.py
@@ -1,6 +1,5 @@
 import json
 import requests
-from copy import deepcopy
 
 
 class Resource(object):
@@ -34,12 +33,13 @@ class Resource(object):
             http://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification
         """
         self.url = url.rstrip('/')
-        self.auth = auth
-        self.verify = verify
+        self.session = requests.Session()
+        self.session.auth = auth
+        self.session.verify = verify
 
-        self.headers = {
+        self.session.headers.update({
             'Content-type': 'application/json',
-        }
+        })
 
     def _api_get(self, url, **kwargs):
         """
@@ -47,12 +47,6 @@ class Resource(object):
         default
         """
         kwargs['url'] = self.url + url
-        kwargs['auth'] = self.auth
-        kwargs['verify'] = self.verify
-
-        headers = deepcopy(self.headers)
-        headers.update(kwargs.get('headers', {}))
-        kwargs['headers'] = headers
         return self._get(**kwargs)
 
     def _get(self, *args, **kwargs):
@@ -62,7 +56,7 @@ class Resource(object):
         :returns: The response of your get
         :rtype: dict
         """
-        response = requests.get(*args, **kwargs)
+        response = self.session.get(*args, **kwargs)
 
         response.raise_for_status()
 
@@ -74,12 +68,6 @@ class Resource(object):
         default
         """
         kwargs['url'] = self.url + url
-        kwargs['auth'] = self.auth
-        kwargs['verify'] = self.verify
-
-        headers = deepcopy(self.headers)
-        headers.update(kwargs.get('headers', {}))
-        kwargs['headers'] = headers
         self._put(**kwargs)
 
     def _put(self, *args, **kwargs):
@@ -91,7 +79,7 @@ class Resource(object):
         """
         if 'data' in kwargs:
             kwargs['data'] = json.dumps(kwargs['data'])
-        response = requests.put(*args, **kwargs)
+        response = self.session.put(*args, **kwargs)
         response.raise_for_status()
 
     def _api_post(self, url, **kwargs):
@@ -100,12 +88,6 @@ class Resource(object):
         default
         """
         kwargs['url'] = self.url + url
-        kwargs['auth'] = self.auth
-        kwargs['verify'] = self.verify
-
-        headers = deepcopy(self.headers)
-        headers.update(kwargs.get('headers', {}))
-        kwargs['headers'] = headers
         self._post(**kwargs)
 
     def _post(self, *args, **kwargs):
@@ -117,7 +99,7 @@ class Resource(object):
         """
         if 'data' in kwargs:
             kwargs['data'] = json.dumps(kwargs['data'])
-        response = requests.post(*args, **kwargs)
+        response = self.session.post(*args, **kwargs)
         response.raise_for_status()
 
     def _api_delete(self, url, **kwargs):
@@ -126,12 +108,6 @@ class Resource(object):
         default
         """
         kwargs['url'] = self.url + url
-        kwargs['auth'] = self.auth
-        kwargs['verify'] = self.verify
-
-        headers = deepcopy(self.headers)
-        headers.update(kwargs.get('headers', {}))
-        kwargs['headers'] = headers
         self._delete(**kwargs)
 
     def _delete(self, *args, **kwargs):
@@ -141,5 +117,5 @@ class Resource(object):
         :returns: The response of your delete
         :rtype: dict
         """
-        response = requests.delete(*args, **kwargs)
+        response = self.session.delete(*args, **kwargs)
         response.raise_for_status()

--- a/rabbitmq_admin/base.py
+++ b/rabbitmq_admin/base.py
@@ -12,7 +12,7 @@ class Resource(object):
     # ```['GET', 'PUT', 'POST', 'DELETE']``"""
     # ALLOWED_METHODS = []
 
-    def __init__(self, url, auth):
+    def __init__(self, url, auth, verify=True):
         """
         :param url: The RabbitMQ API url to connect to. This should include the
             protocol and port number.
@@ -25,9 +25,17 @@ class Resource(object):
         :type auth: Requests auth
 
         .. _Requests' authentication: http://docs.python-requests.org/en/latest/user/authentication/
+
+        :param verify: How to verify SSL certificates used for HTTPS. See
+            `Requests' SSL verification`_ documentation.
+        :type verify: Requests verify
+
+        .. _Requests' SSL verification:
+            http://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification
         """
         self.url = url.rstrip('/')
         self.auth = auth
+        self.verify = verify
 
         self.headers = {
             'Content-type': 'application/json',
@@ -40,6 +48,7 @@ class Resource(object):
         """
         kwargs['url'] = self.url + url
         kwargs['auth'] = self.auth
+        kwargs['verify'] = self.verify
 
         headers = deepcopy(self.headers)
         headers.update(kwargs.get('headers', {}))
@@ -66,6 +75,7 @@ class Resource(object):
         """
         kwargs['url'] = self.url + url
         kwargs['auth'] = self.auth
+        kwargs['verify'] = self.verify
 
         headers = deepcopy(self.headers)
         headers.update(kwargs.get('headers', {}))
@@ -91,6 +101,7 @@ class Resource(object):
         """
         kwargs['url'] = self.url + url
         kwargs['auth'] = self.auth
+        kwargs['verify'] = self.verify
 
         headers = deepcopy(self.headers)
         headers.update(kwargs.get('headers', {}))
@@ -116,6 +127,7 @@ class Resource(object):
         """
         kwargs['url'] = self.url + url
         kwargs['auth'] = self.auth
+        kwargs['verify'] = self.verify
 
         headers = deepcopy(self.headers)
         headers.update(kwargs.get('headers', {}))

--- a/rabbitmq_admin/tests/base_tests.py
+++ b/rabbitmq_admin/tests/base_tests.py
@@ -11,6 +11,7 @@ class ResourceTests(TestCase):
     def setUp(self):
         self.url = 'http://127.0.0.1:15672'
         self.auth = ('guest', 'guest')
+        self.verify = True
 
         self.resource = Resource(self.url, self.auth)
 
@@ -43,7 +44,8 @@ class ResourceTests(TestCase):
             headers={
                 'k1': 'v1',
                 'Content-type': 'application/json'
-            }
+            },
+            verify=self.verify,
         )
 
     @patch.object(requests, 'post', autospec=True)

--- a/rabbitmq_admin/tests/base_tests.py
+++ b/rabbitmq_admin/tests/base_tests.py
@@ -13,16 +13,20 @@ class ResourceTests(TestCase):
         self.auth = ('guest', 'guest')
         self.verify = True
 
-        self.resource = Resource(self.url, self.auth)
+        self.resource = Resource(self.url, self.auth, self.verify)
 
     def test_init(self):
-        resource = Resource(self.url, self.auth)
+        resource = Resource(self.url, self.auth, self.verify)
 
         self.assertEqual(resource.url, self.url)
-        self.assertEqual(resource.auth, self.auth)
-        self.assertEqual(resource.headers, {'Content-type': 'application/json'})
+        self.assertEqual(resource.session.auth, self.auth)
+        self.assertEqual(resource.session.verify, self.verify)
+        self.assertDictContainsSubset(
+            {'Content-type': 'application/json'},
+            resource.session.headers
+        )
 
-    @patch.object(requests, 'put', autospec=True)
+    @patch.object(requests.Session, 'put', autospec=True)
     def test_put_no_data(self, mock_put):
 
         mock_response = Mock()
@@ -40,15 +44,10 @@ class ResourceTests(TestCase):
         self.resource._api_post(url, headers=headers)
         mock_post.assert_called_once_with(
             url=self.url + url,
-            auth=self.auth,
-            headers={
-                'k1': 'v1',
-                'Content-type': 'application/json'
-            },
-            verify=self.verify,
+            headers={'k1': 'v1'}
         )
 
-    @patch.object(requests, 'post', autospec=True)
+    @patch.object(requests.Session, 'post', autospec=True)
     def test_post_no_data(self, mock_post):
 
         mock_response = Mock()
@@ -58,7 +57,7 @@ class ResourceTests(TestCase):
 
         mock_response.raise_for_status.assert_called_once_with()
 
-    @patch.object(requests, 'post', autospec=True)
+    @patch.object(requests.Session, 'post', autospec=True)
     def test_post(self, mock_post):
 
         mock_response = Mock()


### PR DESCRIPTION
If I try and access my RabbitMQ API over HTTPS using a self-signed certificate then I get verification errors with your module. Because it's using Requests under the covers I can exploit `$REQUESTS_CA_BUNDLE` to globally override the CA certificates used but this affects all Requests-using modules in my code; I'd rather have per-module control of this.

This PR exposes the `verify=` parameter for Requests so it can be set to `True`, `False` or a path to either a file containing one or more certificates or a directory of certificates. With this I can verify my self-signed certificates.

Also, while I was in the code I figured you could refactor a fair bit of it in terms of a `requests.Session()` object which allows you to set the `auth`, `verify` & `headers` parameters once and be done with it. That's in the second commit so feel free to drop that if you like the code how it is :smile:
