### PR TITLE
add api support for queue operations

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,1 +1,2 @@
 Micah Hausler (micah.hausler@ambition.com)
+Vaseem Shaikh (vashaikh@wpi.edu)

--- a/rabbitmq_admin/api.py
+++ b/rabbitmq_admin/api.py
@@ -583,7 +583,7 @@ class AdminAPI(Resource):
         :param vhost: The vhost name
         :type vhost: str
 
-        :param body: A body for the exchange.
+        :param body: A body for the queue.
         :type body: dict
         """
         self._api_put(
@@ -598,7 +598,7 @@ class AdminAPI(Resource):
         An individual queue
 
         :param queue: The queue name
-        :type exchange: str
+        :type queue: str
 
         :param vhost: The vhost name
         :type vhost: str
@@ -635,7 +635,7 @@ class AdminAPI(Resource):
         queue contains messages.
 
         :param queue: The queue name
-        :type queues: str
+        :type queue: str
 
         :param vhost: The vhost name
         :type vhost: str

--- a/rabbitmq_admin/api.py
+++ b/rabbitmq_admin/api.py
@@ -275,7 +275,13 @@ class AdminAPI(Resource):
         A list of all vhosts.
         """
         return self._api_get('/api/vhosts')
-
+       
+    def list_feature_flags(self):
+        """
+        A list of all feature flags
+        """
+        return self._api_get('/api/feature-flags')
+    
     def get_vhost(self, name):
         """
         Details about an individual vhost.

--- a/rabbitmq_admin/api.py
+++ b/rabbitmq_admin/api.py
@@ -561,3 +561,51 @@ class AdminAPI(Resource):
         return self._api_get('/api/aliveness-test/{0}'.format(
             urllib.parse.quote_plus(vhost)
         ))
+
+    def list_queues(self):
+        """
+        A list of all queues.
+        """
+        return self._api_get('/api/queues')
+
+    def list_queues_for_vhost(self, vhost):
+        """
+        A list of all queues in a given virtual host.
+
+        :param vhost: The vhost name
+        :type vhost: str
+        """
+        return self._api_get('/api/queues/{0}'.format(
+            urllib.parse.quote_plus(vhost)
+        ))
+
+    def delete_queue_for_vhost(self, queue, vhost, if_unused=False, if_empty=False):
+        """
+        Delete an individual queue. You can add the parameter
+        ``if_unused=True``. This prevents the delete from succeeding if the
+        queue has consumers.
+
+        ``if_empty=True``. This prevents the delete from succeeding if the
+        queue contains messages.
+
+        :param queue: The queue name
+        :type queues: str
+
+        :param vhost: The vhost name
+        :type vhost: str
+
+        :param if_unused: Set to ``True`` to only delete if it is unused
+        :type if_unused: bool
+
+        :param if_empty: Set to ``True`` to only delete if it is empty
+        :type if_empty: bool
+        """
+        self._api_delete(
+            '/api/queues/{0}/{1}'.format(
+                urllib.parse.quote_plus(vhost),
+                urllib.parse.quote_plus(queue)),
+            params={
+                'if-unused': if_unused,
+                'if-empty': if_empty
+            },
+        )

--- a/rabbitmq_admin/api.py
+++ b/rabbitmq_admin/api.py
@@ -490,7 +490,7 @@ class AdminAPI(Resource):
     def create_policy_for_vhost(
             self, vhost, name,
             definition,
-            pattern=None,
+            pattern='',
             priority=0,
             apply_to='all'):
         """

--- a/rabbitmq_admin/api.py
+++ b/rabbitmq_admin/api.py
@@ -562,6 +562,52 @@ class AdminAPI(Resource):
             urllib.parse.quote_plus(vhost)
         ))
 
+    def create_queue_for_vhost(self, queue, vhost, body):
+        """
+        Create an individual queue.
+        The body should look like:
+        ::
+
+            {
+                "auto_delete":false,
+                "durable":true,
+                "arguments":{},
+                "node":"rabbit@smacmullen"
+            }
+
+        All keys are optional.
+
+        :param queue: The queue name
+        :type queue: str
+
+        :param vhost: The vhost name
+        :type vhost: str
+
+        :param body: A body for the exchange.
+        :type body: dict
+        """
+        self._api_put(
+            '/api/queues/{0}/{1}'.format(
+                urllib.parse.quote_plus(vhost),
+                urllib.parse.quote_plus(queue)),
+            data=body
+        )
+
+    def get_queue_for_vhost(self, queue, vhost):
+        """
+        An individual queue
+
+        :param queue: The queue name
+        :type exchange: str
+
+        :param vhost: The vhost name
+        :type vhost: str
+        """
+        return self._api_get('/api/queues/{0}/{1}'.format(
+            urllib.parse.quote_plus(vhost),
+            urllib.parse.quote_plus(queue)
+        ))
+
     def list_queues(self):
         """
         A list of all queues.

--- a/rabbitmq_admin/api.py
+++ b/rabbitmq_admin/api.py
@@ -572,7 +572,7 @@ class AdminAPI(Resource):
                 "auto_delete":false,
                 "durable":true,
                 "arguments":{},
-                "node":"rabbit@smacmullen"
+                "node":"rabbit@rabbit1"
             }
 
         All keys are optional.

--- a/rabbitmq_admin/tests/api_tests.py
+++ b/rabbitmq_admin/tests/api_tests.py
@@ -436,39 +436,39 @@ class AdminAPITests(TestCase):
             {'status': 'ok'}
         )
 
-        def test_list_exchanges(self):
-            self.assertEqual(
-                len(self.api.list_queues()),
-                0
-            )
+    def test_list_queues(self):
+        self.assertEqual(
+            len(self.api.list_queues()),
+            0
+        )
 
-        def test_list_exchanges_for_vhost(self):
-            self.assertEqual(
-                len(self.api.list_queues_for_vhost('/')),
-                0
-            )
+    def test_list_queues_for_vhost(self):
+        self.assertEqual(
+            len(self.api.list_queues_for_vhost('/')),
+            0
+        )
 
-        def test_get_create_delete_queue_for_vhost(self):
-            name = 'my_queue'
-            body = {
-                "auto_delete": False,
-                "durable": True,
-                "arguments": {},
-                "node": "rabbit@rabbit1"
-            }
+    def test_get_create_delete_queue_for_vhost(self):
+        name = 'my_queue'
+        body = {
+            "auto_delete": False,
+            "durable": True,
+            "arguments": {},
+            "node": "rabbit@rabbit1"
+        }
 
-            self.api.create_queue_for_vhost(name, '/', body)
-            self.assertEqual(
-                len(self.api.list_queues_for_vhost('/')),
-                1
-            )
-            self.assertEqual(
-                self.api.get_queue_for_vhost(name, '/').get('name'),
-                name
-            )
+        self.api.create_queue_for_vhost(name, '/', body)
+        self.assertEqual(
+            len(self.api.list_queues_for_vhost('/')),
+            1
+        )
+        self.assertEqual(
+            self.api.get_queue_for_vhost(name, '/').get('name'),
+            name
+        )
 
-            self.api.delete_queue_for_vhost(name, '/')
-            self.assertEqual(
-                len(self.api.list_queues_for_vhost('/')),
-                0
-            )
+        self.api.delete_queue_for_vhost(name, '/')
+        self.assertEqual(
+            len(self.api.list_queues_for_vhost('/')),
+            0
+        )

--- a/rabbitmq_admin/tests/api_tests.py
+++ b/rabbitmq_admin/tests/api_tests.py
@@ -19,7 +19,7 @@ class AdminAPITests(TestCase):
             -p 15672:15672 \
             -e RABBITMQ_DEFAULT_USER=guest \
             -e RABBITMQ_DEFAULT_PASS=guest \
-            -name rabbit1 \
+            --name rabbit1 \
             rabbitmq:3-management
 
     """
@@ -435,3 +435,40 @@ class AdminAPITests(TestCase):
             self.api.is_vhost_alive('/'),
             {'status': 'ok'}
         )
+
+        def test_list_exchanges(self):
+            self.assertEqual(
+                len(self.api.list_queues()),
+                0
+            )
+
+        def test_list_exchanges_for_vhost(self):
+            self.assertEqual(
+                len(self.api.list_queues_for_vhost('/')),
+                0
+            )
+
+        def test_get_create_delete_queue_for_vhost(self):
+            name = 'my_queue'
+            body = {
+                "auto_delete": False,
+                "durable": True,
+                "arguments": {},
+                "node": "rabbit@rabbit1"
+            }
+
+            self.api.create_queue_for_vhost(name, '/', body)
+            self.assertEqual(
+                len(self.api.list_queues_for_vhost('/')),
+                1
+            )
+            self.assertEqual(
+                self.api.get_queue_for_vhost(name, '/').get('name'),
+                name
+            )
+
+            self.api.delete_queue_for_vhost(name, '/')
+            self.assertEqual(
+                len(self.api.list_queues_for_vhost('/')),
+                0
+            )

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ def get_version():
     else:
         raise RuntimeError('Unable to find version string in {0}.'.format(VERSION_FILE))
 
+
 install_requires = [
     'requests>=2.7.0',
     'six>=1.8.0'


### PR DESCRIPTION
Add api support to list, create and delete queues. 
1. Create queue in a vhost
1. retrieve information about a queue
1. list all queues
1. list all queues in a vhost